### PR TITLE
Autocompletion and documentation for BIMserver API

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,78 +3,84 @@ A minimal client for the BIMserver.org REST API
 
 Example:
 
-    # Commit an IFC file into a newly created project
-    
-    import base64
-    import bimserver
-        
-    client = bimserver.api(server_address, username, password)
+```python
+# Commit an IFC file into a newly created project
 
-    deserializer_id = client.ServiceInterface.getDeserializerByName(deserializerName='Ifc2x3tc1 (Streaming)').get('oid')
-    project_id = client.ServiceInterface.addProject(projectName="My new project", schema="ifc2x3tc1").get('oid')
+import base64
+import bimserver
+    
+client = bimserver.api(server_address, username, password)
 
-    with open(fn, "rb") as f:
-        ifc_data = f.read()
-        
-    client.ServiceInterface.checkin(
-        poid=               project_id,
-        comment=            "my first commit",
-        deserializerOid=    deserializer_id,
-        fileSize=           len(ifc_data),
-        fileName=           "IfcOpenHouse.ifc",
-        data=               base64.b64encode(ifc_data).decode('utf-8'),
-        sync=               "false",
-        merge=              "false"
-    )
-    
-    
-    # Download latest revision from a specified project
+deserializer_id = client.ServiceInterface.getDeserializerByName(deserializerName='Ifc2x3tc1 (Streaming)').get('oid')
+project_id = client.ServiceInterface.addProject(projectName="My new project", schema="ifc2x3tc1").get('oid')
 
-    import json
-    from urllib import request
+with open(fn, "rb") as f:
+    ifc_data = f.read()
     
-    project_name = "MyProject"
-    client = bimserver.api(server_address, username, password)
-    projects = client.ServiceInterface.getProjectsByName(name=project_name)
-    project = projects[0]
-    
-    serializer = client.ServiceInterface.getSerializerByName(serializerName='Ifc4 (Streaming)')
-    serializer_id = serializer.get('oid')
-    roid = projects[0].get('lastRevisionId')
-    
-    topicId = client.ServiceInterface.download(
-        roids=[roid],
-        serializerOid=serializer_id,
-        query=json.dumps({}),
-        sync='false',
-    )
-    
-    download_url = f"{server_address}/download?token={client.token}&zip=on&topicId={topicId}"
+client.ServiceInterface.checkin(
+    poid=               project_id,
+    comment=            "my first commit",
+    deserializerOid=    deserializer_id,
+    fileSize=           len(ifc_data),
+    fileName=           "IfcOpenHouse.ifc",
+    data=               base64.b64encode(ifc_data).decode('utf-8'),
+    sync=               "false",
+    merge=              "false"
+)
+```
+
+
+```python
+# Download latest revision from a specified project
+
+import json
+from urllib import request
+
+project_name = "MyProject"
+client = bimserver.api(server_address, username, password)
+projects = client.ServiceInterface.getProjectsByName(name=project_name)
+project = projects[0]
+
+serializer = client.ServiceInterface.getSerializerByName(serializerName='Ifc4 (Streaming)')
+serializer_id = serializer.get('oid')
+roid = projects[0].get('lastRevisionId')
+
+topicId = client.ServiceInterface.download(
+    roids=[roid],
+    serializerOid=serializer_id,
+    query=json.dumps({}),
+    sync='false',
+)
+
+download_url = f"{server_address}/download?token={client.token}&zip=on&topicId={topicId}"
     res = request.urlopen(download_url)
     with open('res.zip', 'wb') as d:
         d.write(res.read())
+```
     
 Or for BIMserver version 1.4:
 
-    # Commit an IFC file into a newly created project
+```python
+# Commit an IFC file into a newly created project
+
+import base64
+import bimserver
+
+client = bimserver.api(server_address, username, password)
+
+deserializer_id = client.Bimsie1ServiceInterface.getSuggestedDeserializerForExtension(extension="ifc").get('oid')
+project_id = client.Bimsie1ServiceInterface.addProject(projectName="My new project").get('oid')
+
+with open("IfcOpenHouse.ifc", "rb") as f:
+    ifc_data = f.read()
     
-    import base64
-    import bimserver
-    
-    client = bimserver.api(server_address, username, password)
-    
-    deserializer_id = client.Bimsie1ServiceInterface.getSuggestedDeserializerForExtension(extension="ifc").get('oid')
-    project_id = client.Bimsie1ServiceInterface.addProject(projectName="My new project").get('oid')
-    
-    with open("IfcOpenHouse.ifc", "rb") as f:
-        ifc_data = f.read()
-        
-    client.Bimsie1ServiceInterface.checkin(
-        poid=               project_id,
-        comment=            "my first commit",
-        deserializerOid=    deserializer_id,
-        fileSize=           len(ifc_data),
-        fileName=           "IfcOpenHouse.ifc",
-        data=               base64.b64encode(ifc_data).decode('utf-8'),
+client.Bimsie1ServiceInterface.checkin(
+    poid=               project_id,
+    comment=            "my first commit",
+    deserializerOid=    deserializer_id,
+    fileSize=           len(ifc_data),
+    fileName=           "IfcOpenHouse.ifc",
+    data=               base64.b64encode(ifc_data).decode('utf-8'),
         sync=               "false"
     )
+```

--- a/README.md
+++ b/README.md
@@ -84,3 +84,11 @@ client.Bimsie1ServiceInterface.checkin(
         sync=               "false"
     )
 ```
+
+Enable autocompletion in Python 2
+
+```python
+import rlcompleter, readline
+readline.parse_and_bind('tab:complete')
+```
+

--- a/bimserver.py
+++ b/bimserver.py
@@ -67,18 +67,16 @@ class Api:
             )            
             
     def __getattr__(self, interface):
-        if self.interfaces is None:   # How should this happen?
-            raise AttributeError("There are no interfaces on this server.")
+        if self.interfaces is None or interface in self.interfaces:
+            return Api.Interface(self, interface)
 
-        if interface not in self.interfaces:
-            # Some form of compatibility:
-            if self.version == "1.4" and not interface.startswith("Bimsie1"):
-                return self.__getattr__("Bimsie1" + interface)
-            elif self.version == "1.5" and interface.startswith("Bimsie1"):
-                return self.__getattr__(interface[len("Bimsie1"):])
+        # Some form of compatibility:
+        if self.version == "1.4" and not interface.startswith("Bimsie1"):
+            return self.__getattr__("Bimsie1" + interface)
+        elif self.version == "1.5" and interface.startswith("Bimsie1"):
+            return self.__getattr__(interface[len("Bimsie1"):])
                 
-            raise AttributeError("'%s' is does not name a valid interface on this server" % interface)
-        return Api.Interface(self, interface)
+        raise AttributeError("'%s' is does not name a valid interface on this server" % interface)
 
     def __dir__(self):
         return sorted(set(Api.__dict__.keys() + self.__dict__.keys()).union(self.interfaces))

--- a/bimserver.py
+++ b/bimserver.py
@@ -72,8 +72,10 @@ class api:
             )            
             
     def __getattr__(self, interface):
-        if self.interfaces is not None and interface not in self.interfaces:
-        
+        if self.interfaces is None:   # How should this happen?
+            raise AttributeError("There are no interfaces on this server.")
+
+        if interface not in self.interfaces:
             # Some form of compatibility:
             if self.version == "1.4" and not interface.startswith("Bimsie1"):
                 return self.__getattr__("Bimsie1" + interface)

--- a/bimserver.py
+++ b/bimserver.py
@@ -46,7 +46,7 @@ class api:
     interfaces = None
     
     def __init__(self, hostname, username=None, password=None):
-        self.url = "%s/json" % hostname
+        self.url = "%s/json" % hostname.strip('/')
         if not hostname.startswith('http://') and not hostname.startswith('https://'):
             self.url = "http://%s" % self.url
             

--- a/bimserver.py
+++ b/bimserver.py
@@ -40,6 +40,13 @@ class api:
             
         def __getattr__(self, method):
             return lambda **kwargs: self.make_request(method, **kwargs)
+
+        def __dir__(self):
+            interFaceMethods =  self.api.MetaInterface.getServiceMethods(serviceInterfaceName="org.bimserver."+self.name)
+            # TODO use long names
+            interFaceMethodNames = [method["name"] for method in interfaceMethods]
+            return sorted(set(api.interface.__dict__.keys() + self.__dict__.keys()).union(interFaceMethodNames))
+
             
             
     token = None
@@ -75,3 +82,6 @@ class api:
                 
             raise AttributeError("'%s' is does not name a valid interface on this server" % interface)
         return api.interface(self, interface)
+
+    def __dir__(self):
+        return sorted(set(api.__dict__.keys() + self.__dict__.keys()).union(self.interfaces))

--- a/bimserver.py
+++ b/bimserver.py
@@ -44,7 +44,7 @@ class api:
         def __dir__(self):
             interFaceMethods =  self.api.MetaInterface.getServiceMethods(serviceInterfaceName="org.bimserver."+self.name)
             # TODO use long names
-            interFaceMethodNames = [method["name"] for method in interfaceMethods]
+            interFaceMethodNames = set(method["name"] for method in interfaceMethods)
             return sorted(set(api.interface.__dict__.keys() + self.__dict__.keys()).union(interFaceMethodNames))
 
             
@@ -57,10 +57,7 @@ class api:
         if not hostname.startswith('http://') and not hostname.startswith('https://'):
             self.url = "http://%s" % self.url
             
-        self.interfaces = set(map(
-            operator.itemgetter("simpleName"), 
-            self.MetaInterface.getServiceInterfaces()
-        ))
+        self.interfaces = set(si["simpleName"] for si in self.MetaInterface.getServiceInterfaces())
         
         self.version = "1.4" if "Bimsie1AuthInterface" in self.interfaces else "1.5"
         

--- a/bimserver.py
+++ b/bimserver.py
@@ -1,5 +1,4 @@
 import json
-import operator
 
 try:
     import urllib2
@@ -8,7 +7,7 @@ except:
     import urllib.request
     urlopen = urllib.request.urlopen
 
-class api:
+class Api:
     """
     A minimal BIMserver.org API client. Interfaces are obtained from the server
     and can be retrieved as attributes from an API instance. The interfaces 
@@ -16,11 +15,11 @@ class api:
     
     Example:
     import bimserver
-    client = bimserver.api(server_address, username, password)
+    client = bimserver.Api(server_address, username, password)
     client.Bimsie1ServiceInterface.addProject(projectName="My new project")
     """
     
-    class interface:
+    class Interface:
         def __init__(self, api, name):
             self.api, self.name = api, name
             
@@ -42,10 +41,9 @@ class api:
             return lambda **kwargs: self.make_request(method, **kwargs)
 
         def __dir__(self):
-            interFaceMethods =  self.api.MetaInterface.getServiceMethods(serviceInterfaceName="org.bimserver."+self.name)
-            # TODO use long names
-            interFaceMethodNames = set(method["name"] for method in interfaceMethods)
-            return sorted(set(api.interface.__dict__.keys() + self.__dict__.keys()).union(interFaceMethodNames))
+            methods =  self.api.MetaInterface.getServiceMethods(serviceInterfaceName="org.bimserver."+self.name) # TODO use long names
+            method_names = set(method["name"] for method in methods)
+            return sorted(set(Api.Interface.__dict__.keys() + self.__dict__.keys()).union(method_names))
 
             
             
@@ -80,7 +78,7 @@ class api:
                 return self.__getattr__(interface[len("Bimsie1"):])
                 
             raise AttributeError("'%s' is does not name a valid interface on this server" % interface)
-        return api.interface(self, interface)
+        return Api.Interface(self, interface)
 
     def __dir__(self):
-        return sorted(set(api.__dict__.keys() + self.__dict__.keys()).union(self.interfaces))
+        return sorted(set(Api.__dict__.keys() + self.__dict__.keys()).union(self.interfaces))


### PR DESCRIPTION
I have added some magic to support interactive use of this client from a Python shell or assistance from an IDE by providing auto-completion and documentation of the BIMserver API. You should now be able to do tab auto-completion for API interfaces and their methods, as well as retrieve documentation on the methods, e.g. `help(client.AuthInterface.login)`. Initial instantiation of the Api class takes a bit longer now.

There are still some things that can be improved:

* follow Python naming convention for function and method names (I understand the camel case with lower initial is not Pythonic),
* parameter retrieval for BIMserver <1.5.183 (There are some calls to `MetaInterface.getServiceMethodParameters` that fail due to a BIMserver bug. We would need a little more fine-grained exception handling to catch and ignore only those particular exceptions.),
* fetch all interfaces with their methods in one single remote call to `MetaInterface.getAllAsJson` (That's how the BIMserver's Console plugin gets the API metadata and I think this would solve the previous issue implicitly. The initialization might also be faster with remote servers, so far I have only tested with a local BIMserver.),
* allow positional arguments in addition to keyword arguments,
* more testing (I am not sure if I considered all corner cases, but have tested with Python 2 and 3).
